### PR TITLE
Avoid OOM errors by shrinking batch group to 4

### DIFF
--- a/src/main/java/loader/AsyncLoaderWorker.java
+++ b/src/main/java/loader/AsyncLoaderWorker.java
@@ -40,7 +40,7 @@ public class AsyncLoaderWorker {
         this.threads = dc.getGlobalConfig().getParallelisation();
         this.databaseName = databaseName;
         this.hasError = new AtomicBoolean(false);
-        this.batchGroup = 32;
+        this.batchGroup = 4;
         this.executor = Executors.newFixedThreadPool(threads, new NamedThreadFactory(databaseName));
     }
 


### PR DESCRIPTION
To avoid OOM errors when loading large files, we shrink the size of the batches in the queue that sits between the CSV reader and the writer threads, from 32 to 4.