### PR TITLE
Use try-with-resources for all transactions

### DIFF
--- a/src/main/java/util/TypeDBUtil.java
+++ b/src/main/java/util/TypeDBUtil.java
@@ -49,11 +49,12 @@ public class TypeDBUtil {
         TypeDBSession schemaSession = getSchemaSession(client, databaseName);
         TypeQLDefine q = TypeQL.parseQuery(schemaAsString);
 
-        TypeDBTransaction writeTransaction = schemaSession.transaction(TypeDBTransaction.Type.WRITE);
-        writeTransaction.query().define(q);
-        writeTransaction.commit();
-        writeTransaction.close();
-        schemaSession.close();
+        try (TypeDBTransaction writeTransaction = schemaSession.transaction(TypeDBTransaction.Type.WRITE)) {
+            writeTransaction.query().define(q);
+            writeTransaction.commit();
+            writeTransaction.close();
+            schemaSession.close();
+        }
 
         Util.info("Defined schema to database <" + databaseName + ">");
     }

--- a/src/main/java/util/Util.java
+++ b/src/main/java/util/Util.java
@@ -188,38 +188,42 @@ public class Util {
     }
 
     public static void setConstrainingAttributeConceptType(Configuration.ConstrainingAttribute[] attributes, TypeDBSession session) {
-        for (Configuration.ConstrainingAttribute attribute : attributes) {
-            attribute.setConceptValueType(session.transaction(TypeDBTransaction.Type.READ));
+        try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.READ)) {
+            for (Configuration.ConstrainingAttribute attribute : attributes) {
+                attribute.setConceptValueType(tx);
+            }
         }
     }
 
     public static void setGetterAttributeConceptType(Configuration.Relation relation, int playerIndex, TypeDBSession session) {
-        if (relation.getPlayers()[playerIndex].getRoleGetter() != null) {
-            Configuration.ThingGetter[] ownershipThingGetters = relation.getPlayers()[playerIndex].getRoleGetter().getOwnershipThingGetters();
-            if (ownershipThingGetters != null) {
-                for (Configuration.ThingGetter ownershipRoleGetter : ownershipThingGetters) {
-                    ownershipRoleGetter.setConceptValueType(session.transaction(TypeDBTransaction.Type.READ));
+        try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.READ)) {
+            if (relation.getPlayers()[playerIndex].getRoleGetter() != null) {
+                Configuration.ThingGetter[] ownershipThingGetters = relation.getPlayers()[playerIndex].getRoleGetter().getOwnershipThingGetters();
+                if (ownershipThingGetters != null) {
+                    for (Configuration.ThingGetter ownershipRoleGetter : ownershipThingGetters) {
+                        ownershipRoleGetter.setConceptValueType(tx);
+                    }
                 }
-            }
-            Configuration.ThingGetter[] thingGetters = relation.getPlayers()[playerIndex].getRoleGetter().getThingGetters();
-            if (thingGetters != null) {
-                for (Configuration.ThingGetter thingGetter : thingGetters) {
-                    if (thingGetter != null) {
-                        Configuration.ThingGetter[] thingThingGetters = thingGetter.getThingGetters();
-                        if (thingThingGetters != null) {
-                            for (Configuration.ThingGetter thingThingGetter : thingThingGetters) {
-                                if (thingThingGetter.getHandler() == TypeHandler.OWNERSHIP) {
-                                    thingThingGetter.setConceptValueType(session.transaction(TypeDBTransaction.Type.READ));
+                Configuration.ThingGetter[] thingGetters = relation.getPlayers()[playerIndex].getRoleGetter().getThingGetters();
+                if (thingGetters != null) {
+                    for (Configuration.ThingGetter thingGetter : thingGetters) {
+                        if (thingGetter != null) {
+                            Configuration.ThingGetter[] thingThingGetters = thingGetter.getThingGetters();
+                            if (thingThingGetters != null) {
+                                for (Configuration.ThingGetter thingThingGetter : thingThingGetters) {
+                                    if (thingThingGetter.getHandler() == TypeHandler.OWNERSHIP) {
+                                        thingThingGetter.setConceptValueType(tx);
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
-        Configuration.RoleGetter attributeRoleGetter = relation.getPlayers()[playerIndex].getRoleGetter();
-        if (attributeRoleGetter != null && attributeRoleGetter.getHandler() == TypeHandler.ATTRIBUTE) {
-            attributeRoleGetter.setConceptValueType(session.transaction(TypeDBTransaction.Type.READ));
+            Configuration.RoleGetter attributeRoleGetter = relation.getPlayers()[playerIndex].getRoleGetter();
+            if (attributeRoleGetter != null && attributeRoleGetter.getHandler() == TypeHandler.ATTRIBUTE) {
+                attributeRoleGetter.setConceptValueType(tx);
+            }
         }
     }
 


### PR DESCRIPTION
## Goal

TypeDB Loader was causing a memory leak in TypeDB because it used transactions without closing them. All transactions need to be correctly closed after they are no longer used.

## Implemented changes

We always use `try` blocks when opening a transaction, to guarantee that they are closed even in the event of error.